### PR TITLE
fix: test edit and create page for items

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,2 +1,3 @@
 class Item < ApplicationRecord
+    validates :name, presence: true
 end

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "new item page", type: :feature do
+describe "edit item page", type: :feature do
     let(:item) do
         Item.create!(
             name: "Harry Potter",

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe "new item page", type: :feature do
+    let(:item) do
+        Item.create!(
+            name: "Harry Potter",
+            description: "Author: J.K.Rowling"
+        )
+    end
+    before(:each) do
+        item = :item
+    end
+    it "should render succesfully and show item details" do
+        visit edit_item_path(item)
+        page.find_field("item[name]", with: item.name)
+        page.find_field("item[description]", with: item.description)
+    end
+    it "should accept input, redirect and update name in database" do
+        visit edit_item_path(item)
+        page.fill_in "item[name]", with: "Harry Potter und die Kammer des Schreckens"
+        page.find("input[type='submit']").click
+        expect(page).to have_text("Item was successfully updated.")
+        expect((Item.find_by name: "Harry Potter und die Kammer des Schreckens").description).to eq(item.description) 
+    end
+end

--- a/spec/features/items/new_spec.rb
+++ b/spec/features/items/new_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe "new item page", type: :feature do
+    before(:each) do
+        @item_title = "Harry Potter und der Stein der Weisen"
+        @item_description = "Buch von J.K.Rowling"
+    end
+    it "should render succesfully" do
+        visit new_item_path
+    end
+    it "should accept input, redirect and write data into database" do
+        visit new_item_path
+        page.fill_in "item[name]", with: @item_title
+        page.fill_in "item[description]", with: @item_description
+        page.find("input[type='submit']").click
+        expect(page).to have_text("Item was successfully created.")
+        expect((Item.find_by name: @item_title).description).to eq(@item_description) 
+    end
+
+end

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "/items", type: :request do
         item = Item.create! valid_attributes
         patch item_url(item), params: { item: new_attributes }
         item.reload
-        skip("Add assertions for updated state")
+        expect(item.name).to eq(new_attributes[:name])
       end
 
       it "redirects to the item" do

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "/items", type: :request do
   }
 
   let(:invalid_attributes) {
-    skip("Add a hash of attributes invalid for your model")
+    { name: "", description: "Item 1 description" }
   }
 
   describe "GET /index" do
@@ -89,7 +89,7 @@ RSpec.describe "/items", type: :request do
   describe "PATCH /update" do
     context "with valid parameters" do
       let(:new_attributes) {
-        skip("Add a hash of attributes valid for your model")
+        { name: "Item 2", description: "Item 2 description" }
       }
 
       it "updates the requested item" do


### PR DESCRIPTION
Added tests for **creation** and **editing** of items, also used some pre-generated tests. They are still 4 pending tests which we suggest to use later in development. We also added **validation** for the item.