### PR TITLE
Permission model

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,23 @@
 class Group < ApplicationRecord
-  has_many :memberships
+  has_many :memberships, dependent: :destroy
   has_many :users, through: :memberships
-  has_many :items
+  has_many :permissions, dependent: :destroy
+  has_many(
+    :managed_items,
+    -> { where(permissions: { permission_type: :can_manage }) },
+    through: :permissions,
+    source: :item
+  )
+  has_many(
+    :viewable_items,
+    -> { where(permissions: { permission_type: :can_view }) },
+    through: :permissions,
+    source: :item
+  )
+  has_many(
+    :lendable_items,
+    -> { where(permissions: { permission_type: :can_lend }) },
+    through: :permissions,
+    source: :item
+  )
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,7 +2,7 @@ class Item < ApplicationRecord
   validates :name, presence: true
   enum :status, inactive: 0, active: 1
 
-  has_many :lendings, dependent: nil
+  has_many :lendings, dependent: :destroy
   has_many :reservations, dependent: :destroy
   has_many :permissions, dependent: :destroy
   has_many(

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,8 +1,26 @@
 class Item < ApplicationRecord
-    validates :name, presence: true
+  validates :name, presence: true
+  enum :status, inactive: 0, active: 1
 
-    has_many :lendings
-    has_many :reservations
-    belongs_to :group, optional: true
-    enum :status, inactive: 0, active: 1
+  has_many :lendings, dependent: nil
+  has_many :reservations, dependent: :destroy
+  has_many :permissions, dependent: :destroy
+  has_many(
+    :manager_groups,
+    -> { where(permissions: { permission_type: :can_manage }) },
+    through: :permissions,
+    source: :group
+  )
+  has_many(
+    :viewer_groups,
+    -> { where(permissions: { permission_type: :can_view }) },
+    through: :permissions,
+    source: :group
+  )
+  has_many(
+    :lender_groups,
+    -> { where(permissions: { permission_type: :can_lend }) },
+    through: :permissions,
+    source: :group
+  )
 end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,0 +1,5 @@
+class Permission < ApplicationRecord
+  belongs_to :item
+  belongs_to :group
+  enum :permission_type, can_view: 0, can_lend: 1, can_manage: 2
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :memberships
+  has_many :memberships, dependent: :destroy
   has_many :groups, through: :memberships
-  has_many :lendings
-  has_many :reservations
+  has_many :lendings, dependent: :destroy
+  has_many :reservations, dependent: :destroy
 end

--- a/db/migrate/20221125173834_create_permissions.rb
+++ b/db/migrate/20221125173834_create_permissions.rb
@@ -1,0 +1,13 @@
+class CreatePermissions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :permissions do |t|
+      t.belongs_to :item, null: false, foreign_key: true
+      t.belongs_to :group, null: false, foreign_key: true
+      t.integer :permission_type, null: false # enum, see Permission model
+
+      t.timestamps
+    end
+
+    remove_column :items, :group_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_21_205846) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_25_173834) do
   create_table "groups", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -23,8 +23,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_21_205846) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "status", default: 0, null: false
-    t.integer "group_id"
-    t.index ["group_id"], name: "index_items_on_group_id"
   end
 
   create_table "lendings", force: :cascade do |t|
@@ -47,6 +45,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_21_205846) do
     t.datetime "updated_at", null: false
     t.index ["group_id"], name: "index_memberships_on_group_id"
     t.index ["user_id"], name: "index_memberships_on_user_id"
+  end
+
+  create_table "permissions", force: :cascade do |t|
+    t.integer "item_id", null: false
+    t.integer "group_id", null: false
+    t.integer "permission_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_permissions_on_group_id"
+    t.index ["item_id"], name: "index_permissions_on_item_id"
   end
 
   create_table "reservations", force: :cascade do |t|
@@ -72,11 +80,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_21_205846) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "items", "groups"
   add_foreign_key "lendings", "items"
   add_foreign_key "lendings", "users"
   add_foreign_key "memberships", "groups"
   add_foreign_key "memberships", "users"
+  add_foreign_key "permissions", "groups"
+  add_foreign_key "permissions", "items"
   add_foreign_key "reservations", "items"
   add_foreign_key "reservations", "users"
 end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :group do
-    membership { nil }
-    name { "MyString" }
+    name { "Group Name" }
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :item do
-    name { "MyString" }
-    description { "MyString" }
-    group { nil}
+    name { "Item Name" }
+    description { "Item Description" }
   end
 end

--- a/spec/factories/permissions.rb
+++ b/spec/factories/permissions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :permission do
+    item { nil }
+    group { nil }
+    permission_type { 1 }
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,5 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe Group, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:group) { FactoryBot.create(:group) }
+
+  it "can have multiple items with different permissions" do
+    item1 = FactoryBot.create(:item)
+    item2 = FactoryBot.create(:item)
+    item3 = FactoryBot.create(:item)
+
+    group.permissions.create(item: item1, permission_type: :can_manage)
+    group.permissions.create(item: item2, permission_type: :can_view)
+    group.permissions.create(item: item3, permission_type: :can_lend)
+    group.permissions.create(item: item3, permission_type: :can_view)
+
+    expect(group.managed_items.count).to eq(1)
+    expect(group.managed_items.first).to eq(item1)
+
+    expect(group.viewable_items.count).to eq(2)
+    expect(group.viewable_items.first).to eq(item2)
+    expect(group.viewable_items.second).to eq(item3)
+
+    expect(group.lendable_items.count).to eq(1)
+    expect(group.lendable_items.first).to eq(item3)
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,5 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe Item, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:item) { FactoryBot.create(:item) }
+
+  it "can have multiple groups with different permissions" do
+    group1 = FactoryBot.create(:group)
+    group2 = FactoryBot.create(:group)
+    group3 = FactoryBot.create(:group)
+
+    item.permissions.create(group: group1, permission_type: :can_manage)
+    item.permissions.create(group: group2, permission_type: :can_view)
+    item.permissions.create(group: group3, permission_type: :can_lend)
+    item.permissions.create(group: group3, permission_type: :can_view)
+
+    expect(item.manager_groups.count).to eq(1)
+    expect(item.manager_groups.first).to eq(group1)
+
+    expect(item.viewer_groups.count).to eq(2)
+    expect(item.viewer_groups.first).to eq(group2)
+    expect(item.viewer_groups.second).to eq(group3)
+
+    expect(item.lender_groups.count).to eq(1)
+    expect(item.lender_groups.first).to eq(group3)
+  end
 end

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Permission, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Closes #56.

Introduces a `Permission` model between `Item` and `Group` which specifies a `can_manage`, `can_view` or `can_lend` type. This way multiple groups can be assigned multiple permissions for a given item.

Groups now support a `managed_items`, `viewable_items` and `lendable_items` method for easy access to the items to which the group has permissions. 

Items now support a `manager_groups`, `viewer_groups` and `lender_groups` method for easy access to the groups which have permissions for the item.