### PR TITLE
Disallow null values for dates in lending and reservation

### DIFF
--- a/db/migrate/20221127115524_disallow_null_for_dates.rb
+++ b/db/migrate/20221127115524_disallow_null_for_dates.rb
@@ -1,0 +1,9 @@
+class DisallowNullForDates < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null(:lendings, :started_at, false)
+    change_column_null(:lendings, :due_at, false)
+    
+    change_column_null(:reservations, :starts_at, false)
+    change_column_null(:reservations, :ends_at, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_25_173834) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_27_115524) do
   create_table "groups", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -28,9 +28,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_25_173834) do
   create_table "lendings", force: :cascade do |t|
     t.integer "item_id", null: false
     t.integer "user_id", null: false
-    t.datetime "started_at"
+    t.datetime "started_at", null: false
     t.datetime "completed_at"
-    t.datetime "due_at"
+    t.datetime "due_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["item_id"], name: "index_lendings_on_item_id"
@@ -60,8 +60,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_25_173834) do
   create_table "reservations", force: :cascade do |t|
     t.integer "item_id", null: false
     t.integer "user_id", null: false
-    t.datetime "starts_at"
-    t.datetime "ends_at"
+    t.datetime "starts_at", null: false
+    t.datetime "ends_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["item_id"], name: "index_reservations_on_item_id"


### PR DESCRIPTION
The `started_at` and `due_at` date in a `lending` are the main way to determine, whether a lending exists or not and therefore they shouldn't be `nil`.  The `completed_at` date in a `lending` however can be nil, because that would mean the lending is still active.

The same is true for `starts_at, ends_at` dates of a reservation.