### PR TITLE
chore: add rubocop to recommended vscode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "misogi.ruby-rubocop"
+  ]
+}


### PR DESCRIPTION
This PR adds the VSCode rubocop extension to the VSCode recommendations, resulting in a prompt that'll be shown to users:
<img width="671" alt="Screenshot 2022-11-29 at 12 27 04" src="https://user-images.githubusercontent.com/14912729/204517270-db79b121-e824-49bb-9813-bcee7c141d28.png">

Follow-up to #54.