### PR TITLE
feat: set user name field from OIDC info

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,7 @@ class User < ApplicationRecord
     # rather than the the ID of the locally persisted user.
     where(provider: auth.provider, uid: auth.uid).first_or_create! do |user|
       # All information returned by OpenID Connect is passed in `auth` param
+      user.full_name = auth.info.name
       user.email = auth.info.email
       user.password = Devise.friendly_token[0, 20]
     end


### PR DESCRIPTION
closes #156

Previously created users will not have their name updated as they already exist. To verify changes, delete your user / drop the db and re-authenticate w/ OIDC.