### PR TITLE
Cl/button permissions item showpage

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,15 @@ class User < ApplicationRecord
     false
   end
 
+  def managing_rights?(item)
+    item_groups = item.manager_groups
+
+    groups.each do |user_group|
+      return true if item_groups.include? user_group
+    end
+    false
+  end
+
   # Handles user creation based on data returned from OIDC login process. If
   # the user already exists, returns the user.
   def self.from_omniauth(auth)

--- a/app/views/items/_item_largescreen.html.erb
+++ b/app/views/items/_item_largescreen.html.erb
@@ -59,9 +59,14 @@
             <div id="item-location-large" style="height: 240px;"></div>
           </div>
           <%# Button %>
-          <%= link_to I18n.t("items.buttons.edit"), edit_item_path(@item) %> |
-          <%= link_to I18n.t("items.buttons.back"), items_path %> |
-          <%= link_to I18n.t("items.buttons.download_qrcode") , download_path(@item) %>
+          <div>
+            <% if current_user.managing_rights?(@item) %>
+              <%= button_to I18n.t("items.buttons.edit"), edit_item_path(@item), method: :get, class: "mx-auto btn btn-primary"%> |
+              <%= button_to I18n.t("items.buttons.delete"), item_path(@item), method: :delete, data: { turbo_confirm: I18n.t("items.messages.deletion_confirmation")}, class: "mx-auto btn btn-primary"%> |
+              <%= button_to I18n.t("items.buttons.download_qrcode") , download_path(@item), method: :get, class: "mx-auto btn btn-primary"  %> |
+            <% end %>
+            <%= button_to I18n.t("items.buttons.back"), items_path, method: :get, class: "mx-auto btn btn-primary"%>
+          </div>
           <%# <%= button_to "Destroy this item", @item, method: :delete %>
           <div class="d-flex justify-content-center w-100 mb-5">
             <% if current_user.lending_rights?(@item) and @src_is_qrcode  %>

--- a/app/views/items/_item_smallscreen.html.erb
+++ b/app/views/items/_item_smallscreen.html.erb
@@ -45,9 +45,14 @@
     </tbody>
   </table>
   <%# Main Button %>
-  <%= link_to I18n.t("items.buttons.edit"), edit_item_path(@item) %> |
-  <%= link_to I18n.t("items.buttons.back"), items_path %> |
-  <%= link_to I18n.t("items.buttons.download_qrcode"), download_path(@item) %>
+  <div>
+    <% if current_user.managing_rights?(@item) %>
+      <%= button_to I18n.t("items.buttons.edit"), edit_item_path(@item), method: :get, class: "mx-auto btn btn-primary"%> |
+      <%= button_to I18n.t("items.buttons.delete"), item_path(@item), method: :delete, data: { turbo_confirm: I18n.t("items.messages.deletion_confirmation")}, class: "mx-auto btn btn-primary"%> |
+      <%= button_to I18n.t("items.buttons.download_qrcode") , download_path(@item), method: :get, class: "mx-auto btn btn-primary"  %> |
+    <% end %>
+    <%= button_to I18n.t("items.buttons.back"), items_path, method: :get, class: "mx-auto btn btn-primary"%>
+  </div>
   <%# <%= button_to "Destroy this item", @item, method: :delete %>
   <div class="button-blocker">
   </div>

--- a/config/locales/views/landing_page/de.yml
+++ b/config/locales/views/landing_page/de.yml
@@ -9,11 +9,13 @@ de:
       successfully_destroyed: "Item wurde erfolgreich zerstört."
       successfully_borrowed: "Item wurde erfolgreich ausgeliehen"
       successfully_returned: "Item wurde erfolgreich zurückgegeben"
+      deletion_confirmation: "Soll das Item wirklich gelöscht werden?"
     buttons:
       new: "Item erstellen"
       update: "Item aktualisieren"
       show: "Item anzeigen"
       edit: "Item bearbeiten"
+      delete: "Item löschen"
       back: "Zurück zur Items Übersicht"
       borrow: "Ausleihen"
       return: "Zurückgeben"

--- a/config/locales/views/landing_page/en.yml
+++ b/config/locales/views/landing_page/en.yml
@@ -7,11 +7,13 @@ en:
       successfully_destroyed: "Item was successfully destroyed."
       successfully_borrowed: "Item was successfully borrowed"
       successfully_returned: "Item was successfully returned"
+      deletion_confirmation: "Do you really want to delete the item?"
     buttons:
       new: "Create item"
       update: "Update item"
       show: "Show item"
       edit: "Edit item"
+      delete: "Delete item"
       back: "Back to items"
       borrow: "Borrow"
       return: "Return"

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -68,4 +68,26 @@ describe "show item page", type: :feature do
     expect(page).to have_text(item2.name)
   end
 
+  it "display edit, delete and download button if user has managing rights" do
+    sign_in @user
+
+    group = FactoryBot.create(:group)
+    membership = Membership.new(role: 1, user_id: @user.id, group: group)
+
+    @user.memberships.push(membership)
+    @item.manager_groups.push(group)
+
+    visit item_path(@item)
+    expect(page).to have_text(:visible, "Edit item")
+    expect(page).to have_text(:visible, "Delete item")
+    expect(page).to have_text(:visible, "Download QR-Code")
+  end
+
+  it "not display edit, delete and download button if user has no managing rights" do
+    sign_in @user
+    visit item_path(@item)
+    expect(page).not_to have_text(:visible, "Edit item")
+    expect(page).not_to have_text(:visible, "Delete item")
+    expect(page).not_to have_text(:visible, "Download QR-Code")
+  end
 end


### PR DESCRIPTION
Closes #128

Um Feature zu testen können zwei Items erstellt werden Default mäßig, sollten der User keine Berechtigung haben das Item zu bearbeiten. Für das hinzufügen des Users in eine Managing Gruppe des Items können aktuell in app/models/user.rb  managing_rights? folgende Code Zeilen hinzugefügt werden und nach einmaligen ausführen wieder gelöscht werden.

@testGroup = Group.new(name: "Test Group")
@testGroup.save
@testMembership = Membership.new(role: 1, user_id: id, group: @testGroup)
@testMembership.save

item_groups = item.manager_groups
user_memberships = memberships
user_memberships.push(@testMembership)
user_groups = groups
item_groups.push(@testGroup)