### PR TITLE
fix: change column type of isbn to bigint

### DIFF
--- a/db/migrate/20221215093316_isbn_column_to_bigint.rb
+++ b/db/migrate/20221215093316_isbn_column_to_bigint.rb
@@ -1,0 +1,11 @@
+class IsbnColumnToBigint < ActiveRecord::Migration[7.0]
+  def up
+    change_column_default(:items, :isbn, nil)
+    change_column(:items, :isbn, :bigint)
+  end
+
+  def down
+    change_column_default(:items, :isbn, :bigint)
+    change_column(:items, :isbn, :integer)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_12_151347) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_15_093316) do
   create_table "groups", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false


### PR DESCRIPTION
We need to use `change_column` to change the column type in a table. A previous migration uses `change_column_default`, which changes the default value of newly added entities.