### PR TITLE
fix: broken notification test

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -82,7 +82,7 @@ $mobileDeviceCutoff: 992px;
 
 @media (min-width: $mobileDeviceCutoff) {
   .mobile-only {
-    display: none;
+    display: none !important;
   }
 }
 

--- a/spec/features/notifications/destroy_spec.rb
+++ b/spec/features/notifications/destroy_spec.rb
@@ -14,6 +14,7 @@ describe "Notification inbox", type: :feature do
     end
 
     it "no longer shows a notification when it is dismissed" do
+      Capybara.current_session.current_window.resize_to(1600, 900)
       NotificationMailer.send_info("Test_2", user).deliver_now
       visit root_path
       page.find_by_id("notification-inbox-button").click


### PR DESCRIPTION
- window was rendered with small screensize
- notification button isn't visible on mobile
- test couldn't find visible button
- fixed by increasing window size to render desktop version

- also fixed css bug
   - round "Create item" button was always visible