### PR TITLE
feat: add manage, borrow and viewing rights to own items

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -83,8 +83,15 @@ class ItemsController < ApplicationController
     @item = Item.new(item_params(params[:item_type]))
     @item.item_type = params[:item_type]
 
+    item_saved = @item.save
+    if item_saved
+      Permission.create(item: @item, group: current_user.personal_group, permission_type: :can_borrow)
+      Permission.create(item: @item, group: current_user.personal_group, permission_type: :can_manage)
+      Permission.create(item: @item, group: current_user.personal_group, permission_type: :can_view)
+    end
+
     respond_to do |format|
-      if @item.save
+      if item_saved
         format.html { redirect_to item_url(@item), notice: I18n.t("items.messages.successfully_created") }
         format.json { render :show, status: :created, location: @item }
       else

--- a/spec/features/items/new_spec.rb
+++ b/spec/features/items/new_spec.rb
@@ -1,12 +1,8 @@
 require "rails_helper"
 
 describe "new item page", type: :feature do
-  before do
-    @item_title = "Harry Potter und der Stein der Weisen"
-    @item_description = "Buch von J.K.Rowling"
-    @item_max_reservation_days = 2
-    @item_max_borrowing_days = 7
-  end
+  let(:password) { 'password' }
+  let(:user) { FactoryBot.create(:user, password: password) }
 
   # rubocop:todo RSpec/NoExpectationExample
   it "renders succesfully" do
@@ -15,6 +11,12 @@ describe "new item page", type: :feature do
   # rubocop:enable RSpec/NoExpectationExample
 
   it "accepts input, redirect and write data into database" do
+    @item_title = "Harry Potter und der Stein der Weisen"
+    @item_description = "Buch von J.K.Rowling"
+    @item_max_reservation_days = 2
+    @item_max_borrowing_days = 7
+
+    sign_in user
     visit new_item_path
     page.fill_in "item[name]", with: @item_title
     page.fill_in "item[description]", with: @item_description
@@ -23,6 +25,32 @@ describe "new item page", type: :feature do
     page.click_button("item_type")
     expect(page).to have_text("Item was successfully created.")
     expect((Item.find_by name: @item_title).description).to eq(@item_description)
+  end
+
+  it "sets the managing, borrowing and viewing rights of the item creator" do
+    sign_in user
+    expect(user.exists_personal_group?).to be(true)
+
+    personal_group = user.personal_group
+    expect(personal_group.managed_items.count).to eq(0)
+    expect(personal_group.viewable_items.count).to eq(0)
+    expect(personal_group.borrowable_items.count).to eq(0)
+
+    visit new_item_path
+    page.fill_in "item[name]", with: "An item name"
+    page.click_button("item_type")
+
+    item = Item.find_by(name: "An item name")
+    expect(personal_group.managed_items.count).to eq(1)
+    expect(personal_group.managed_items.first).to eq(item)
+    expect(user.can_manage?(item)).to be(true)
+
+    expect(personal_group.viewable_items.count).to eq(1)
+    expect(personal_group.viewable_items.first).to eq(item)
+
+    expect(personal_group.borrowable_items.count).to eq(1)
+    expect(personal_group.borrowable_items.first).to eq(item)
+    expect(user.can_borrow?(item)).to be(true)
   end
 
 end


### PR DESCRIPTION
closes #178 
In addition to `can_manage` rights, I also added `can_view` and `can_borrow` permissions for items that are created by the user, because it was almost the same code and a separate issue for that would be overkill in my opinion. Furthermore, borrowing wasn't possible at the moment, due to the missing permission.