### PR TITLE
feat: limit length of group and item attributes

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,7 +1,7 @@
 # Model of the current group
 class Group < ApplicationRecord
   enum tag: { verified_group: 0, personal_group: 1, everyone_group: 2 }
-  validates :name, presence: true
+  validates :name, presence: true, length: { minimum: 1, maximum: 50 }
   has_many :memberships, dependent: :destroy
   has_many :users, through: :memberships
   has_many :permissions, dependent: :destroy

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,7 +3,8 @@
 class Item < ApplicationRecord
   include ExportPdf
 
-  validates :name, presence: true
+  validates :name, presence: true, length: { minimum: 1, maximum: 100 }
+  validates :description, allow_blank: true, length: { minimum: 1, maximum: 1500 }
   validates :max_reservation_days, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 365 }
   validates :max_borrowing_days, numericality: { greater_than_or_equal_to: 0 }
 

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>
+<h1 style="overflow-wrap: break-word;">
   <%= render GroupNameComponent.new(group: @group) %>
   <button type="button" class="btn btn-sm btn-primary bi bi-pencil-fill" data-bs-toggle="modal" data-bs-target="#editGroupModal">
   </button>

--- a/app/views/items/_item_largescreen.html.erb
+++ b/app/views/items/_item_largescreen.html.erb
@@ -42,7 +42,7 @@
             <div class="container">
               <div class="row">
                 <%# name%>
-                <h1 class="col-sm-7"><%= @item.name %></h1>
+                <h1 class="col-sm-9"><%= @item.name %></h1>
                 <%# available badge%>
                 <div class="col-sm-3 ms-auto">
                   <%= render(ItemAvailabilityBadgeComponent.new(item: @item, user: current_user)) %>

--- a/app/views/items/_item_smallscreen.html.erb
+++ b/app/views/items/_item_smallscreen.html.erb
@@ -7,7 +7,7 @@
   <div class="container">
     <div class="row">
       <%# name%>
-      <h1 class="col-sm-7"><%= @item.name %></h1>
+      <h1 class="col-sm-10" style="overflow-wrap: break-word;"><%= @item.name %></h1>
       <%# available badge%>
       <div class="col-sm-2 ms-auto">
         <%= render(ItemAvailabilityBadgeComponent.new(item: @item, user: current_user)) %>

--- a/app/views/items/_owner_component.html.erb
+++ b/app/views/items/_owner_component.html.erb
@@ -1,6 +1,8 @@
 <%# owner / can_manage%>
 <% owner_groups = Group.owner_groups(item.id) %>
-<p>
+<p class="mx-4 text-truncate">
     <%= I18n.t("items.card_text.owner") %>
-    <span class="text-primary"><%=owner_groups.map{|owner| owner.name}.join(", ").html_safe%></span>
+    <span class="text-primary" title="<%=owner_groups.map{|owner| owner.name}.join(',')%>">
+        <%=owner_groups.map{|owner| owner.name}.join(", ")%>
+    </span>
 </p>

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe Group, type: :model do
   let(:group) { FactoryBot.create(:group) }
 
+  it "name is limited in length" do
+    item = FactoryBot.build(:group, name: "a" * 51)
+    expect(item).not_to be_valid
+  end
+
   it "can have multiple items with different permissions" do
     item1 = FactoryBot.create(:item)
     item2 = FactoryBot.create(:item)

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -223,4 +223,14 @@ RSpec.describe Item, type: :model do
     expect(other.attribute?("isbn")).to be false
   end
 
+  it "name is limited in length" do
+    item = FactoryBot.build(:item, name: "a" * 101)
+    expect(item).not_to be_valid
+  end
+
+  it "description is limited in length" do
+    item = FactoryBot.build(:item, description: "a" * 1501)
+    expect(item).not_to be_valid
+  end
+
 end


### PR DESCRIPTION
- limit length of group and item name to 100 characters
- limit length of item description to 1500 characters
- add text breaking to group name to avoid vertical scrolling for long names
- editing group name is broken since it doesn't show the user the error message
- still missing limit for number of groups with permissions
- not sure if that should really be implemented anyway

Resolves #172