### PR TITLE
Rename personal groups after their member

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,7 @@ class User < ApplicationRecord
   def create_personal_group
     raise StandardError, "#{self} already has personal group" if exists_personal_group?
 
-    p_group = Group.create(name: "personal_group", tag: :personal_group)
+    p_group = Group.create(name: full_name, tag: :personal_group)
     p_group_membership = Membership.create(group_id: p_group.id, user_id: id, role: :member)
     memberships.push(p_group_membership)
     save

--- a/db/migrate/20230120094018_rename_personal_groups_to_member_name.rb
+++ b/db/migrate/20230120094018_rename_personal_groups_to_member_name.rb
@@ -1,3 +1,4 @@
+  # Update the names of all personal groups to the full name of their first member
 class RenamePersonalGroupsToMemberName < ActiveRecord::Migration[7.0]
   def change
     Group.where(tag: :personal_group).each do | group |

--- a/db/migrate/20230120094018_rename_personal_groups_to_member_name.rb
+++ b/db/migrate/20230120094018_rename_personal_groups_to_member_name.rb
@@ -1,0 +1,8 @@
+class RenamePersonalGroupsToMemberName < ActiveRecord::Migration[7.0]
+  def change
+    Group.where(tag: :personal_group).each do | group |
+      group.name = group.memberships.first.user.full_name
+      group.save!
+    end
+  end
+end

--- a/db/migrate/20230120094018_rename_personal_groups_to_member_name.rb
+++ b/db/migrate/20230120094018_rename_personal_groups_to_member_name.rb
@@ -1,7 +1,7 @@
-  # Update the names of all personal groups to the full name of their first member
+# Update the names of all personal groups to the full name of their first member
 class RenamePersonalGroupsToMemberName < ActiveRecord::Migration[7.0]
   def change
-    Group.where(tag: :personal_group).each do | group |
+    Group.where(tag: :personal_group).each do |group|
       group.name = group.memberships.first.user.full_name
       group.save!
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_23_084800) do
+ActiveRecord::Schema[7.0].define(version: 20_230_120_094_018) do
   create_table "groups", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_230_120_094_018) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_23_084800) do
   create_table "groups", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,6 +13,7 @@ describe User, type: :model do
 
   it "is able to access personal group" do
     p_group = user.create_personal_group
+    expect(p_group.name).to eq(user.full_name)
     expect(user.exists_personal_group?).to be(true)
     expect(user.personal_group).to eq(p_group)
   end


### PR DESCRIPTION
This PR adds a migration to rename all personal groups to the full name of their owner and adds code to name new personal groups after their owner at creation.

 Closes #291 