### PR TITLE
Use HTTPS on Heroku app

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/config/initializers/force_ssl.rb
+++ b/config/initializers/force_ssl.rb
@@ -1,0 +1,1 @@
+Rails.application.routes.default_url_options[:protocol] = 'https' if Rails.application.config.force_ssl


### PR DESCRIPTION
This should fix the following problem:

Generating a QR code on Heroku app includes HTTP instead of HTTPS, making it impossible to use the QR code scanner once on the HTTP version.