### PR TITLE
Make item availability badge visible again

### DIFF
--- a/app/views/items/_item_card.html.erb
+++ b/app/views/items/_item_card.html.erb
@@ -1,5 +1,5 @@
 <div class="card">
-    <div class="w-100 d-flex justify-content-end p-2" style="position: absolute; left: 0px; top: 0px;">
+    <div class="w-100 d-flex justify-content-end p-2" style="position: absolute; left: 0px; top: 0px; z-index: 1">
         <%= render(ItemAvailabilityBadgeComponent.new(item: item, user: current_user)) %>
     </div>
     <a class="text-black text-decoration-none" href=<%=item_path(item)%>>


### PR DESCRIPTION
Problem: The item images added in #243 were on top of the labels that show whether items are available or borrowed.
Fix: Added z-index of 1 to the label which makes it stay on top of the images.