### PR TITLE
fix: select items unique and table entries switched to correct mode

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -2,11 +2,11 @@ class AnalyticsController < ApplicationController
   # rubocop:disable Metrics/AbcSize
   def show
     if params[:mode].blank? || params[:mode] == "me"
-      @lendings = current_user.lendings.order('created_at DESC')
-      @select_items = @lendings.map { |lending| lending.item.name }
-    elsif params[:mode] == "other"
       @lendings = Lending.where(item: current_user.items).order('created_at DESC')
-      @select_items = @lendings.map { |lending| lending.item.name }
+      @select_items = @lendings.map { |lending| lending.item.name }.uniq
+    elsif params[:mode] == "other"
+      @lendings = current_user.lendings.order('created_at DESC')
+      @select_items = @lendings.map { |lending| lending.item.name }.uniq
     else
       []
     end

--- a/spec/features/analytics/lending_history_spec.rb
+++ b/spec/features/analytics/lending_history_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "borrowed items", type: :feature do
 
   it "shows the history of items that i've borrowed" do
     sign_in user1
-    visit "#{analytics_path}?mode=me"
+    visit "#{analytics_path}?mode=other"
 
     table = page.find('tbody')
 
@@ -50,7 +50,7 @@ RSpec.describe "borrowed items", type: :feature do
 
   it "shows the history of items that i've lent" do
     sign_in user1
-    visit "#{analytics_path}?mode=other"
+    visit "#{analytics_path}?mode=me"
 
     table = page.find('tbody')
 


### PR DESCRIPTION
Fixes history table filter dropdown contains only unique items. Also the tables were switched and not corresponding to their mode (borrowed from me or borrowed by me)