### PR TITLE
fix: permissions can't be deleted

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -393,7 +393,8 @@ class ItemsController < ApplicationController
 
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def create_permission
-    @item.permissions.joins(:group).where.not('groups.tag': 'personal_group').destroy_all
+    @item.permissions.joins(:group).where('groups.tag': [nil, "everyone_group"]).destroy_all
+
     permissions = []
     params.each do |key, value|
       next unless key.start_with?("permission_")

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -7,9 +7,8 @@ describe "edit item page", type: :feature do
     @user2 = FactoryBot.create(:user, email: 'example2@mail.com')
     @group = FactoryBot.create(:group)
     @group2 = FactoryBot.create(:group)
-    FactoryBot.create(:permission, group: @group, item: @item, permission_type: :can_view)
-    FactoryBot.create(:permission, group: @group2, item: @item, permission_type: :can_view)
     FactoryBot.create(:permission, group: @group, item: @item, permission_type: :can_manage)
+    FactoryBot.create(:permission, group: @group2, item: @item, permission_type: :can_view)
     FactoryBot.create(:membership, user: @user, group: @group)
     FactoryBot.create(:membership, user: @user2, group: @group2)
   end
@@ -29,21 +28,19 @@ describe "edit item page", type: :feature do
   end
   # rubocop:enable RSpec/NoExpectationExample
 
-  it "accepts input, redirect and update name in database" do
-    sign_in @user
-    visit edit_item_path(@item)
-    page.fill_in "item[name]", with: "Harry Potter und die Kammer des Schreckens"
-    page.find("button[type='submit'][value='#{@item.item_type}']").click
-    expect(page).to have_text("Item was successfully updated.")
-    expect((Item.find_by name: "Harry Potter und die Kammer des Schreckens").description).to eq(@item.description)
-  end
-
   context 'with JS', driver: :selenium_chrome, js: true, ui: true do
+    it "accepts input, redirect and update name in database" do
+      sign_in @user
+      visit edit_item_path(@item)
+      page.fill_in "item[name]", with: "Harry Potter und die Kammer des Schreckens"
+      page.find("button[type='submit'][value='#{@item.item_type}']").click
+      expect(page).to have_text("Item was successfully updated.")
+      expect((Item.find_by name: "Harry Potter und die Kammer des Schreckens").description).to eq(@item.description)
+    end
+
     it "renders the correct preselected permission" do
       sign_in @user
-      @user.memberships.push(@membership)
-      item.manager_groups.push(@group)
-      visit edit_item_path(item)
+      visit edit_item_path(@item)
       select_group = page.find_by_id("permission_select_0_group_id").value
       expect(select_group).to eq(@group.id.to_s)
       select_level = find_by_id("permission_select_0_level").value
@@ -53,22 +50,17 @@ describe "edit item page", type: :feature do
     it "updates the permissions after submitting the form" do
       sign_in @user
       @group2 = FactoryBot.create(:group)
-      @user.memberships.push(@membership)
-      item.manager_groups.push(@group)
-      visit edit_item_path(item)
-      page.find_by_id("add-permission-button").click
+      visit edit_item_path(@item)
       select @group2.name, from: "permission_select_1_group_id"
       select "can manage", from: "permission_select_1_level"
-      page.find("button[type='submit'][value='#{item.item_type}']").click
+      page.find("button[type='submit'][value='#{@item.item_type}']").click
       sleep 0.5 # Waiting for JS to execute (not ideal, but works)
-      expect(Permission.permission_for_group(@group2.id, item.id)).to eq("can_manage")
+      expect(Permission.permission_for_group(@group2.id, @item.id)).to eq("can_manage")
     end
 
     it "shows an error message and disables button if a group has multiple permissions selected" do
       sign_in @user
-      @user.memberships.push(@membership)
-      item.manager_groups.push(@group)
-      visit edit_item_path(item)
+      visit edit_item_path(@item)
       page.find_by_id("add-permission-button").click
       select @group.name, from: "permission_select_1_group_id"
       select "can borrow", from: "permission_select_1_level"


### PR DESCRIPTION
The sql query

```
@item.permissions.joins(:group).where.not('groups.tag': "personal_group")
```
does only detect groups with tag "everyone_group" NOT the groups with tag `nil`. Therefore it does not delete the normal groups which leads to their duplication.
If you do the opposite and don't use `not` it works:

```
@item.permissions.joins(:group).where('groups.tag': [nil, "everyone_group"])
```

resolves #398 